### PR TITLE
feat(linter): Allow symbol errors to show (static analysys)

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -35,7 +35,11 @@ interface LintErrorType {
  */
 const getErrors = (text: string): ReadonlyArray<LintErrorType> => {
   const results = [];
-  const pattern = /^error: (.+), at .+:(\d+):(\d+)$/gm;
+  // matches both syntax error messages, like:
+  // `error: syntax error, unexpected ']', expecting ';', at /home/foo/bar/shell.nix:19:3`
+  // as well as symbol error messages, like
+  // `error: undefined variable 'openjdk' at /home/foo/bar/shell.nix:14:5`
+  const pattern = /^error: (.+) at .+:(\d+):(\d+)$/gm;
   // We need to loop through the regexp here, so a let is required
   let match = pattern.exec(text);
   while (match !== null) {


### PR DESCRIPTION
`nix-instantiate --parse` does not just show you sytnax errors, it
also has a simple *static analysis* phase, which will check for
symbols that are not in scope.

For example, for the nix expression:

```
{ pkgs }:
openjdk
```

nix will highlight openjdk, which cannot work since it is not in
scope (user missed that it needs to be in `pkgs.openjdk`).

This is extremely helpful.

Note that `with pkgs;` will turn off this analysis inside of the
`with` expression subtree, because now nix cannot guarantee anything
about symbols (any symbol could dynamically come from `pkgs`, which is
unknown statically).

The fix itself is very easy, these messages don’t have a comma before
the at, so just changing the regex a bit gives us this feature.