### PR TITLE
feat: add configurable formatter path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Adds [nix](https://nixos.org/) language support for VSCode Editor.
 
 * When `Language Server` support is not enabled the following tools are used to
   + Formatting support
-    - with the help of [nixpkgs-format](https://github.com/nix-community/nixpkgs-fmt)
+    - with the help of [nixpkgs-format](https://github.com/nix-community/nixpkgs-fmt) or other tools as specified by the `nix.formatterPath` option
   + Error Report
     - Using `nix-instantiate` errors reported
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
     "configuration": {
       "title": "NixIDE",
       "properties": {
+        "nix.formatterPath": {
+          "type": "string",
+          "default": "nixpkgs-fmt",
+          "description": "Location of the nix formatter command."
+        },
         "nix.serverPath": {
           "type": "string",
           "default": "rnix-lsp",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,10 @@ export class Config {
     return this.cfg.get<T>(path) ?? def_val;
   }
 
+  get formatterPath(): string {
+    return this.get<string>("formatterPath", "nixpkgs-fmt");
+  }
+
   get serverPath(): string {
     return this.get<string>("serverPath", "rnix-lsp");
   }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -7,8 +7,9 @@ import {
   TextEdit,
 } from "vscode";
 import { IProcessResult, runInWorkspace } from "./process-runner";
+import { config } from "./configuration";
 
-const FORMATTER = "nixpkgs-fmt";
+const FORMATTER = config.formatterPath;
 
 /**
  * Get text edits to format a range in a document.
@@ -33,7 +34,9 @@ const getFormatRangeEdits = async (
     );
   } catch (error) {
     if (error instanceof Error) {
-      await vscode.window.showErrorMessage(`Failed to run ${FORMATTER}: ${error.message}`);
+      await vscode.window.showErrorMessage(
+        `Failed to run ${FORMATTER}: ${error.message}`
+      );
     }
     // Re-throw the error to make the promise fail
     throw error;


### PR DESCRIPTION
Adds support for `nix.formatterPath` to do...exactly what the title says, and makes a note of the change in the README.

Closes #60 

@jnoortheen I've tested this locally and everything is good to go, but feel free to give it a second pass! I'm not sure whether bumping the version to 0.1.17 belongs in this, or if you'd prefer to do it separately? If that should be included here just let me know.