### PR TITLE
provide default configuration for [nix] files

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,12 @@
           "description": "Use LSP instead of nix-instantiate and nixpkgs-fmt."
         }
       }
+    },
+    "configurationDefaults": {
+      "[nix]": {
+        "editor.insertSpaces": true,
+        "editor.tabSize": 2
+      }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
the provided default configuration uses 2 spaces for indentation,
which is what nixpkgs-fmt uses
