### PR TITLE
fix: mark interpolation as meta.embedded instead of markup.italic

### DIFF
--- a/syntaxes/nix.YAML-tmLanguage
+++ b/syntaxes/nix.YAML-tmLanguage
@@ -415,7 +415,7 @@ repository:
           - include: "#comment-remark"
 
   interpolation:
-    name: markup.italic
+    name: meta.embedded
     begin: \$\{
     beginCaptures: { "0": { name: punctuation.section.embedded.begin.nix } }
     end: \}


### PR DESCRIPTION
Reasoning:
- It's the theme's job to make variables or interpolation italic or not
- Some themes don't have a color for variables, resulting in whatever is inside the curly brackets being colored as string:
![image](https://user-images.githubusercontent.com/31318219/163708242-610bd339-cfac-4d12-a778-9cdbd233a7a2.png)
Themes should reset `meta.embedded` to the default text color.