### PR TITLE
formatterPath array and filename argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,14 @@ Adds [nix](https://nixos.org/) language support for VSCode Editor.
 * Full editing support with [rnix-LSP](https://github.com/nix-community/rnix-lsp)
 
 * When `Language Server` support is not enabled the following tools are used to
-  + Formatting support
-    - with the help of [nixpkgs-format](https://github.com/nix-community/nixpkgs-fmt) or other tools as specified by the `nix.formatterPath` option
+  + Formatting support. Set `nix.formatterPath` to any command which can accept file contents on stdin and return formatted text on stdout; e.g.,
+      ```json
+      {
+        "nix.formatterPath": "nixpkgs-fmt" // default
+        // "nix.formatterPath": "nixfmt" 
+        // "nix.formatterPath": ["nix", "fmt", "--", "-"] // using flakes with `formatter = pkgs.alejandra;`
+      }
+      ```
   + Error Report
     - Using `nix-instantiate` errors reported
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Adds [nix](https://nixos.org/) language support for VSCode Editor.
       {
         "nix.formatterPath": "nixpkgs-fmt" // default
         // "nix.formatterPath": "nixfmt" 
+        // "nix.formatterPath": ["treefmt", "--stdin", "{file}"]
         // "nix.formatterPath": ["nix", "fmt", "--", "-"] // using flakes with `formatter = pkgs.alejandra;`
       }
       ```

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
       "title": "NixIDE",
       "properties": {
         "nix.formatterPath": {
-          "type": "string",
+          "type": ["string", "array"],
           "default": "nixpkgs-fmt",
           "description": "Location of the nix formatter command."
         },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,7 +17,7 @@ export class Config {
     return this.cfg.get<T>(path) ?? def_val;
   }
 
-  get formatterPath(): string {
+  get formatterPath(): string | Array<string> {
     return this.get<string>("formatterPath", "nixpkgs-fmt");
   }
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -9,7 +9,10 @@ import {
 import { IProcessResult, runInWorkspace } from "./process-runner";
 import { config } from "./configuration";
 
-const FORMATTER = config.formatterPath;
+const FORMATTER: Array<string> =
+  config.formatterPath instanceof Array
+    ? config.formatterPath
+    : [config.formatterPath];
 
 /**
  * Get text edits to format a range in a document.
@@ -29,13 +32,13 @@ const getFormatRangeEdits = async (
   try {
     result = await runInWorkspace(
       vscode.workspace.getWorkspaceFolder(document.uri),
-      [FORMATTER],
+      FORMATTER,
       document.getText(actualRange)
     );
   } catch (error) {
     if (error instanceof Error) {
       await vscode.window.showErrorMessage(
-        `Failed to run ${FORMATTER}: ${error.message}`
+        `Failed to run ${FORMATTER.join(" ")}: ${error.message}`
       );
     }
     // Re-throw the error to make the promise fail

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -30,6 +30,9 @@ const getFormatRangeEdits = async (
   );
   let result: IProcessResult;
   try {
+    FORMATTER.forEach(
+      (elm, i) => (FORMATTER[i] = elm.replace("{file}", document.fileName))
+    );
     result = await runInWorkspace(
       vscode.workspace.getWorkspaceFolder(document.uri),
       FORMATTER,


### PR DESCRIPTION
These changes allow the `formatterPath`:
-  to be an array; some formatters aren't a single command (e.g., `nix fmt` -- which itself insists on editing files in-place but can be made to only print to stdout, depending on the formatter configured).
- to take the filename as an argument; this allows formatters like treefmt (#241) which supports more than one language and thus requires the filename to determine (I'm guessing) the filetype (e.g., `cat default.nix | treefmt --stdout {file}`).

The latter is fairly dependent on the former which is why I've included it here instead of a separate PR.