### PR TITLE
fix: catch error if serverPath doesn't exist

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -14,9 +14,7 @@ import commandExists = require("command-exists");
 let client: LanguageClient;
 
 export async function activate(context: ExtensionContext): Promise<void> {
-  const cmdExists = await commandExists(config.serverPath);
-
-  if (!cmdExists) {
+  if (!commandExists.sync(config.serverPath)) {
     const selection = await window.showErrorMessage<UriMessageItem>(
       `Command ${config.serverPath} not found in $PATH`,
       {


### PR DESCRIPTION
These changes fix the `command-exists` function usage such that the extension doesn't fail to activate if `enableLanguageServer` is `true` and `serverPath` is not in `$PATH`; which currently throws the following error:

![Screenshot from 2022-08-15 21-00-25](https://user-images.githubusercontent.com/32495955/184771195-d5770c3b-f21a-4c1e-86de-24683eadb04a.png)

With the changes in this PR, the error is properly handled:

![Screenshot from 2022-08-15 21-01-03](https://user-images.githubusercontent.com/32495955/184771376-c370dd73-f0c8-478c-8c09-392e86ba6121.png)

Fixes #203.