### PR TITLE
feat: open terminal links for store paths in workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The following are tested so far:
 
 * Snippets
 
+* Terminal links to store paths open (if file exists) in workspace.
+
 ## Todos
 
 **PRs welcome** for them

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,14 @@ import { startLinting } from "./linter";
 import { config } from "./configuration";
 import * as client from "./client";
 
+const storePath = process.env["NIX_STORE_DIR"] || "/nix/store";
+const storeRegex = new RegExp(`${storePath}/.{32}-[^/]*/([^:]*)`, "g");
+
+interface StoreTerminalLink extends vscode.TerminalLink {
+  relPath: string;
+  absPath: string;
+}
+
 /**
  * Activate this extension.
  *
@@ -28,6 +36,45 @@ export async function activate(context: ExtensionContext): Promise<void> {
     ].map((func) => func("nix", formattingProviders));
     context.subscriptions.concat(subs);
   }
+
+  vscode.window.registerTerminalLinkProvider({
+    provideTerminalLinks: (
+      context: vscode.TerminalLinkContext,
+      token: vscode.CancellationToken
+    ) => {
+      const matches = [...context.line.matchAll(storeRegex)];
+      if (matches.length === 0) {
+        return [];
+      }
+
+      return matches.map((match) => {
+        return {
+          startIndex: context.line.indexOf(match[0]),
+          length: match[0].length,
+          tooltip: `Open file in workspace ${match[1]}`,
+          absPath: match[0],
+          relPath: match[1],
+        };
+      });
+    },
+    handleTerminalLink: (link: StoreTerminalLink) => {
+      // get absolute path to workspace, if it exists
+      const root = vscode.workspace.workspaceFolders
+        ? vscode.workspace.workspaceFolders[0].uri
+        : vscode.Uri.file("");
+      let uri = vscode.Uri.joinPath(root, link.relPath);
+
+      try {
+        // check if file exists
+        void vscode.workspace.fs.stat(uri);
+      } catch {
+        // if not, use store path
+        uri = vscode.Uri.file(link.absPath);
+      } finally {
+        void vscode.commands.executeCommand("vscode.open", uri);
+      }
+    },
+  });
 }
 
 export async function deactivate(): Promise<void> {


### PR DESCRIPTION
These changes register a terminal link handler so that store paths can be handled as files relative to the workspace (if they exist in the workspace).

As it stands, this assumes the store is at `/nix/store` and that all paths are unix-style (which _should_ cover most (all?) users but I can try to abstract those away if necessary).

fixes #272 