### PR TITLE
feat: declare support for nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Adds [nix](https://nixos.org/) language support for VSCode Editor.
 
   ![](./images/docs/md-embed-nix.png)
 
-* Full editing support when using a language server. Generally, any nix [LSP](https://microsoft.github.io/language-server-protocol/) implementation should work but only the following have been tested:
+* Full editing support when using a language server. Generally, any nix [LSP](https://microsoft.github.io/language-server-protocol/) implementation should work.  
+The following are tested so far:
 
   - [rnix-lsp](https://github.com/nix-community/rnix-lsp)
   - [nil](https://github.com/oxalica/nil)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,17 @@ Adds [nix](https://nixos.org/) language support for VSCode Editor.
 
   ![](./images/docs/md-embed-nix.png)
 
-* Full editing support with [rnix-LSP](https://github.com/nix-community/rnix-lsp)
+* Full editing support when using a language server. Generally, any nix [LSP](https://microsoft.github.io/language-server-protocol/) implementation should work but only the following have been tested:
+
+  - [rnix-lsp](https://github.com/nix-community/rnix-lsp)
+  - [nil](https://github.com/oxalica/nil)
+
+    ```jsonc
+    {
+      "nix.serverPath": "rnix-lsp"
+      // "nix.serverPath": "nil"
+    }
+    ```
 
 * When `Language Server` support is not enabled the following tools are used to
   + Formatting support. Set `nix.formatterPath` to any command which can accept file contents on stdin and return formatted text on stdout; e.g.,


### PR DESCRIPTION
A quick docs update to make it clearer that any (so far as I understand) language server which implements the LSP _should_ work with this extension. Addresses (or closes, even) #274.