### PR TITLE
Tell people to use `"nix.enableLanguageServer": true` in settings to enable LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following are tested so far:
 
     ```jsonc
     {
+      "nix.enableLanguageServer": true,
       "nix.serverPath": "rnix-lsp"
       // "nix.serverPath": "nil"
     }


### PR DESCRIPTION
Currently, the docs do not say this - I was confused why it wasn't working until I read the [nil readme](https://github.com/oxalica/nil/blob/2e688f98a47046c9590a03eec8eb3b0e16815381/README.md#vscodevscodium-with-nix-ide).