### PR TITLE
docs: saying that nixd is tested and add an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The following are tested so far:
 
     ```jsonc
     {
-        // settings for 'nixd' LSP
         "nix.serverSettings": {
+            // settings for 'nixd' LSP
             "nixd": {
                 "eval": {
                     // stuff

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following are tested so far:
 
     ```jsonc
     {
-        // Settings for 'nixd' LSP
+        // settings for 'nixd' LSP
         "nix.serverSettings": {
             "nixd": {
                 "eval": {

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The following are tested so far:
 
   - [rnix-lsp](https://github.com/nix-community/rnix-lsp)
   - [nil](https://github.com/oxalica/nil)
+  - [nixd](https://github.com/nix-community/nixd)
 
     ```jsonc
     {
@@ -41,6 +42,38 @@ The following are tested so far:
             "command": ["nixpkgs-fmt"]
           }
         }
+      }
+    }
+    ```
+
+    ```jsonc
+    {
+        // Settings for 'nixd' LSP
+        "nix.serverPath": "nixd",
+        "nix.serverSettings": {
+            "nixd": {
+                "eval": {
+                    // stuff
+                },
+                "formatting": {
+                    "command": "nixpkgs-fmt"
+                },
+                "options": {
+                    "enable": true,
+                    "target": {
+                        // tweak arguments here
+                        "args": [],
+                        // NixOS options
+                        "installable": "<flakeref>#nixosConfigurations.<name>.options"
+
+                        // Flake-parts options
+                        // "installable": "<flakeref>#debug.options"
+
+                        // Home-manager options
+                        // "installable": "<flakeref>#homeConfigurations.<name>.options"
+                    }
+                }
+            }
       }
     }
     ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The following are tested so far:
       "nix.enableLanguageServer": true,
       "nix.serverPath": "rnix-lsp"
       // "nix.serverPath": "nil"
+      // "nix.serverPath": "nixd"
     }
     ```
 
@@ -49,7 +50,6 @@ The following are tested so far:
     ```jsonc
     {
         // Settings for 'nixd' LSP
-        "nix.serverPath": "nixd",
         "nix.serverSettings": {
             "nixd": {
                 "eval": {


### PR DESCRIPTION
The upstream (nixd) license is under LGPL though, I (author of nixd) explictly re-license configuration docs here in MIT.

Fixes: #337 