### PR TITLE
Improve snippet usability

### DIFF
--- a/snippets.json
+++ b/snippets.json
@@ -6,7 +6,7 @@
   },
   "let": {
     "prefix": ["let"],
-    "body": ["let $0;", "in"],
+    "body": ["let $1;", "in $0"],
     "description": "Let expression"
   },
   "rec": {
@@ -16,7 +16,7 @@
   },
   "with": {
     "prefix": ["with"],
-    "body": ["with $0;"],
+    "body": ["with $1; $0"],
     "description": "With expression"
   }
 }

--- a/snippets.json
+++ b/snippets.json
@@ -16,7 +16,7 @@
   },
   "with": {
     "prefix": ["with"],
-    "body": ["with $1; $0"],
+    "body": ["with $1;$0"],
     "description": "With expression"
   }
 }


### PR DESCRIPTION
This may be pretty subjective, but as a long time user of this extension, the built-in snippets for `let` and `with` are pretty annoying in that they don't add a space to the end of the expansion and don't move the cursor there.

I believe there are two common use cases for the snippets, both of which are not very pleasant with the current version:
* writing a new expression:
```nix
let<tab>
```
... which gets expanded to
```nix
let |;
in
```
... to which I add my desired bindings. Now I want to continue after the `in`, but I can't without manually moving my cursor there.
* modifying an existing expression:
```nix
let<tab>{
    ...
}
```
... which gets expanded to
```nix
let |;
in{
    ...
}
```
... to which I add my desired bindings. Now I have to move after the `in` and add a space, so the code looks nice. (yeah, this is kinda a job for a formatter, but I'm not satisfied with any of the currently available for nix)

Pretty much the same applies to `with`.

The proposed fix makes both of these use cases much more pleasant without being too annoying for any other. The only degradation I can think of is for people who like to keep the `in`/`with` on separate lines and don't have trailing whitespace trimming on, who would now have to delete the space manually. Still, that is just one extra keypress, so it's probably not too bad.