### PR TITLE
Take latest Node.js version in shell.nix by default

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> { } }:
 pkgs.mkShell {
   buildInputs = with pkgs; [
-    nodejs-16_x
+    nodejs
     yarn
     esbuild
   ];


### PR DESCRIPTION
To resolve

```
error: Package ‘nodejs-16.20.2’ is marked as insecure, refusing to evaluate.

       Known issues:
        - This NodeJS release has reached its end of life. See https://nodejs.org/en/about/releases/.
```