### PR TITLE
Provide an option to suppress LSP not found in path warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The following are tested so far:
       // "nix.serverPath": "nixd"
     }
     ```
+  
+  You can suppress the language server not found in `$PATH` warnings using `suppressLanguageServerNotFoundWarnings`.
 
   Pass settings to the language server via `serverSettings`.
     ```jsonc

--- a/package.json
+++ b/package.json
@@ -92,6 +92,11 @@
           "default": false,
           "description": "Use LSP instead of nix-instantiate and nixpkgs-fmt."
         },
+        "nix.suppressLanguageServerNotFoundWarnings": {
+          "type": "boolean",
+          "default": false,
+          "description": "Suppress warnings about the LSP not being found in the $PATH."
+        },
         "nix.serverSettings": {
           "type": "object",
           "default": {},

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,9 @@ let client: LanguageClient;
 
 export async function activate(context: ExtensionContext): Promise<void> {
   if (!commandExists.sync(config.serverPath)) {
+    if (config.suppressLSPNotFoundWarnings) {
+      return;
+    }
     const selection = await window.showErrorMessage<UriMessageItem>(
       `Command ${config.serverPath} not found in $PATH`,
       {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -30,6 +30,10 @@ export class Config {
     return this.get<boolean>("enableLanguageServer", false);
   }
 
+  get suppressLSPNotFoundWarnings(): boolean {
+    return this.get<boolean>("suppressLanguageServerNotFoundWarnings", false);
+  }
+
   get serverSettings(): LSPObject {
     return this.get<LSPObject>("serverSettings", {});
   }


### PR DESCRIPTION
I believe there should be an option to suppress `Command not found in $PATH`. Personally, I only use the language server when it is provided by a dev shell. In other projects, the pop-up warnings are not useful to me. I am aware that I can set the option per project but having it globally works much more seamlessly.