### PR TITLE
feat: add restarting language server command

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,14 @@
         "editor.insertSpaces": true,
         "editor.tabSize": 2
       }
-    }
+    },
+    "commands": [
+      {
+        "title": "Restart Language Server",
+        "category": "Nix IDE",
+        "command": "nix-ide.restartLanguageServer"
+      }
+    ]
   },
   "devDependencies": {
     "@commitlint/cli": "*",

--- a/src/client.ts
+++ b/src/client.ts
@@ -79,3 +79,16 @@ export async function activate(context: ExtensionContext): Promise<void> {
 export function deactivate(): Thenable<void> | undefined {
   return client ? client.stop() : undefined;
 }
+
+export async function restart(context: ExtensionContext): Promise<void> {
+  const disposable = window.setStatusBarMessage(
+    "$(loading~spin) Restarting Nix language server",
+  );
+  try {
+    client ? await client.restart() : await activate(context);
+  } catch (error) {
+    client?.error("Failed to restart Nix language server", error, "force");
+  } finally {
+    disposable.dispose();
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,11 @@ import * as client from "./client";
  */
 export async function activate(context: ExtensionContext): Promise<void> {
   if (config.LSPEnabled) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand("nix-ide.restartLanguageServer", () =>
+        client.restart(context),
+      ),
+    );
     await client.activate(context);
   } else {
     await startLinting(context);


### PR DESCRIPTION
Hi there. I've made a patch to resolve #362.

If something wrong with this PR, please feel free to point it out.
Thank you.

## Description

Add a command `> Nix IDE: Restart Language Server` to restart the language server (or simply start if not running).

https://github.com/nix-community/vscode-nix-ide/assets/41154684/55536c81-956b-4608-a771-6b789cc91ea4
