### PR TITLE
feat: support use vscode variables in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Pass settings to the language server via the `serverSettings` option.
                 },
                 "home-manager": {
                     "expr": "(builtins.getFlake \"/absolute/path/to/flake\").homeConfigurations.<name>.options"
+                },
+                // Tip: use ${workspaceFolder} variable to define path
+                "nix-darwin": {
+                  "expr": "(builtins.getFlake \"${workspaceFolder}/path/to/flake\").darwinConfigurations.<name>.options"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
   },
   "dependencies": {
     "command-exists": "^1.2.9",
-    "vscode-languageclient": "^9.0.0"
+    "vscode-languageclient": "^9.0.0",
+    "vscode-variables": "^0.1.3"
   }
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,6 +2,7 @@ import { WorkspaceConfiguration, workspace } from "vscode";
 import { LSPObject } from "vscode-languageclient";
 
 import { MessageItem, Uri } from "vscode";
+import { transformConfigValueByVscodeVariables } from "./utils";
 
 export interface UriMessageItem extends MessageItem {
   uri: Uri;
@@ -14,8 +15,13 @@ export class Config {
     return workspace.getConfiguration(this.rootSection);
   }
 
-  private get<T>(path: string, def_val: T): T {
-    return this.cfg.get<T>(path) ?? def_val;
+  private get<T extends string | boolean | LSPObject>(
+    path: string,
+    def_val: T,
+  ): T {
+    return transformConfigValueByVscodeVariables(
+      this.cfg.get<T>(path) ?? def_val,
+    );
   }
 
   get formatterPath(): string | Array<string> {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,6 @@
+declare module "vscode-variables" {
+  export default function variables(
+    string: string,
+    recursive?: boolean,
+  ): string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,34 @@
+import { LSPObject } from "vscode-languageclient";
+import variables from "vscode-variables";
+
+/**
+ * transform config value by vscode variables
+ * @link https://www.npmjs.com/package/vscode-variables?activeTab=readme
+ */
+export const transformConfigValueByVscodeVariables = <
+  T extends string | boolean | LSPObject,
+>(
+  _cfg: T,
+): T => {
+  let cfg = _cfg;
+  try {
+    if (typeof cfg === "string") {
+      cfg = variables(cfg) as T;
+    } else if (!!cfg && typeof cfg === "object") {
+      Object.keys(cfg).forEach((key) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        cfg[key] = transformConfigValueByVscodeVariables(cfg[key]);
+      });
+    } else if (Array.isArray(cfg) && cfg.length > 0) {
+      cfg = cfg.map(
+        (item) => transformConfigValueByVscodeVariables(item) as unknown,
+      ) as T;
+    }
+    return cfg;
+  } catch (err) {
+    console.error(err);
+    return cfg;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3578,6 +3578,11 @@ vscode-languageserver-types@3.17.5:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz#3273676f0cf2eab40b3f44d085acbb7f08a39d8a"
   integrity sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==
 
+vscode-variables@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/vscode-variables/-/vscode-variables-0.1.3.tgz#7d035e66dbeec7385d04de6478ff942f53fa4178"
+  integrity sha512-atxTgTGoSxtsUIqTKRozIB122meW6uMw5DWkdyeC7ibUX6mLUFi/F+w1ZoqMSx4BTgvhsD98UGlEaMDNtRP4Qg==
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"


### PR DESCRIPTION
https://github.com/nix-community/nixd/blob/main/nixd/docs/configuration.md#where-to-place-the-configuration

According to the above document, when defining the expr of options, only absolute paths can be used. This is very inconvenient for configuring across machines. Therefore, this PR introduces the [vscode-variables](https://www.npmjs.com/package/vscode-variables) package to support using `${workspaceFolder}` in configuration files to define paths.

before

```json
{
    "nixd": {
      "options": {
        "nixpkgs": {
          "expr": "import <nixpkgs> { }"
        },
        "nix-darwin": {
          "expr": "(builtins.getFlake \"/absolute/path/to/flake\").darwinConfigurations.default.options"
        }
      }
    }
}
```

after

```json
{
    "nixd": {
      "options": {
        "nixpkgs": {
          "expr": "import <nixpkgs> { }"
        },
        "nix-darwin": {
          "expr": "(builtins.getFlake \"${workspaceFolder}/flake\").darwinConfigurations.default.options"
        }
      }
    }
}
```
