### PR TITLE
feat: add setting to suppress error notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,15 @@
           "type": "object",
           "default": {},
           "description": "Settings passed to the language server on configuration requests."
+        },
+        "nix.hiddenLanguageServerErrors": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Error notifications from the language server for these request types will be suppressed.",
+          "examples": [
+            [ "textDocument/definition", "textDocument/documentSymbol" ]
+          ]
         }
       }
     },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -36,6 +36,10 @@ export class Config {
     return this.get<boolean>("enableLanguageServer", false);
   }
 
+  get hiddenErrorKinds(): string[] {
+    return this.get("hiddenLanguageServerErrors", []);
+  }
+
   get serverSettings(): LSPObject {
     return this.get<LSPObject>("serverSettings", {});
   }


### PR DESCRIPTION
Workaround for #387 

This is based on https://github.com/dotnet/vscode-csharp/pull/7106 which was designed to solve a similar problem, as far as I can tell.

This could probably also be made more specific, e.g. with string matchers for error messages or things like that, but I'd probably advocate for language server implementations to fix their errors instead of making a complex configuration in the client.

To test, I configured
```jsonc
    "nix.serverPath": "nixd",
    "nix.hiddenLanguageServerErrors" : [
        "textDocument/definition",
    ],
```
and it seems to work! I have also seen language server crash and things like that, but those are a separate matter and not fixable with this particular error handler. 