### PR TITLE
fix: reload language server client on restart

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,8 @@
-import { WorkspaceConfiguration, workspace } from "vscode";
+import {
+  ConfigurationChangeEvent,
+  WorkspaceConfiguration,
+  workspace,
+} from "vscode";
 import { LSPObject } from "vscode-languageclient";
 
 import { MessageItem, Uri } from "vscode";
@@ -42,6 +46,15 @@ export class Config {
 
   get serverSettings(): LSPObject {
     return this.get<LSPObject>("serverSettings", {});
+  }
+
+  requiresServerRestart(change: ConfigurationChangeEvent): boolean {
+    // NOTE: this might be easier if all the settings were nested under
+    // e.g. `"nix.languageServer" or something like that, to deduplicate keys
+    return (
+      change.affectsConfiguration("nix.serverPath") ||
+      change.affectsConfiguration("nix.enableLanguageServer")
+    );
   }
 }
 export const config = new Config();


### PR DESCRIPTION
Ensure the client watcher and output channel are disposed during a restart before the new client is creates, and also show a helper warning when certain variables are changed that require a restart.

Also catch errors starting the client, so that our restart configuration change handler is still registered in case the user fixes their serverPath or something like that. Similarly, always register the restart command in case user wants to start using language server after
not using it before.

Closes #419