### PR TITLE
readme: updated formatterPath for nix fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It can be changed by setting `nix.formatterPath` to any command which can accept
 "nix.formatterPath": "nixpkgs-fmt" 
     // "nix.formatterPath": "nixfmt"
     // "nix.formatterPath": ["treefmt", "--stdin", "{file}"]
-    // "nix.formatterPath": ["nix", "fmt", "--", "-"] // using flakes with `formatter = pkgs.alejandra;`
+    // "nix.formatterPath": ["nix", "fmt", "--", "--"] // using flakes with `formatter = pkgs.alejandra;`
 }
 ```
 


### PR DESCRIPTION
`nix fmt -- -` does not seem to work with `nixpkgs-fmt`. `nix fmt -- --` seems to work fine with `nixpkgs-fmt` and `nixfmt-rfc-style`.

closes #413