### PR TITLE
feat: support (Neo)Vim by coc.nvim

### DIFF
--- a/coc-nix/.npmignore
+++ b/coc-nix/.npmignore
@@ -1,0 +1,8 @@
+# Ignore everything
+/*
+
+# Whitelist what you need
+!dist/
+!images/*
+!snippets.json
+*.map

--- a/coc-nix/README.md
+++ b/coc-nix/README.md
@@ -1,0 +1,28 @@
+# nix-ide
+
+Ported from [vscode-nix-ide](https://github.com/nix-community/vscode-nix-ide).
+
+Because some APIs of [vscode](github.com/microsoft/vscode) are missing in
+[coc.nvim](https://github.com/neoclide/coc.nvim), disable some features
+temporarily:
+
+- validate range: miss `vscode.document.validateRange()`
+- rerun linter only when document is dirty: miss `vscode.document.isDirty`
+- open URL of language server: miss `vscode.env.openExternal()`
+
+## Install
+
+- [coc-marketplace](https://github.com/fannheyward/coc-marketplace)
+- [npm](https://www.npmjs.com/package/coc-nix)
+- vim:
+
+```vim
+" command line
+CocInstall coc-nix
+" or add the following code to your vimrc
+let g:coc_global_extensions = ['coc-nix', 'other coc-plugins']
+```
+
+## Usage
+
+Refer [vscode-nix-ide](https://github.com/nix-community/vscode-nix-ide).

--- a/coc-nix/package.json
+++ b/coc-nix/package.json
@@ -1,0 +1,168 @@
+{
+  "name": "coc-nix",
+  "displayName": "Nix IDE",
+  "description": "Nix language support - syntax highlighting, formatting, and error reporting.",
+  "version": "0.3.1",
+  "publisher": "jnoortheen",
+  "icon": "images/icon.png",
+  "license": "MIT",
+  "engines": {
+    "coc": "^0.0.82"
+  },
+  "categories": [
+    "Programming Languages",
+    "Formatters",
+    "Snippets"
+  ],
+  "keywords": [
+    "coc.nvim",
+    "nix",
+    "IDE"
+  ],
+  "bugs": {
+    "url": "https://github.com/nix-community/vscode-nix-ide/issues"
+  },
+  "homepage": "https://github.com/nix-community/vscode-nix-ide",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nix-community/vscode-nix-ide"
+  },
+  "main": "dist/extension.js",
+  "activationEvents": [
+    "onLanguage:nix"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "nix",
+        "aliases": [
+          "Nix",
+          "nix"
+        ],
+        "extensions": [
+          ".nix"
+        ],
+        "icon": {
+          "dark": "images/icon.png",
+          "light": "images/icon.png"
+        },
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "nix",
+        "scopeName": "source.nix",
+        "path": "./syntaxes/nix.tmLanguage.json"
+      },
+      {
+        "scopeName": "markdown.nix.codeblock",
+        "path": "./syntaxes/injection.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.nix": "nix"
+        }
+      }
+    ],
+    "snippets": [
+      {
+        "language": "nix",
+        "path": "./snippets.json"
+      }
+    ],
+    "configuration": {
+      "title": "NixIDE",
+      "properties": {
+        "nix.formatterPath": {
+          "type": [
+            "string",
+            "array"
+          ],
+          "default": "nixpkgs-fmt",
+          "description": "Location of the nix formatter command."
+        },
+        "nix.serverPath": {
+          "type": "string",
+          "default": "nil",
+          "description": "Location of the nix language server command."
+        },
+        "nix.enableLanguageServer": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use LSP instead of nix-instantiate and nixpkgs-fmt."
+        },
+        "nix.serverSettings": {
+          "type": "object",
+          "default": {},
+          "description": "Settings passed to the language server on configuration requests."
+        },
+        "nix.hiddenLanguageServerErrors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Error notifications from the language server for these request types will be suppressed.",
+          "examples": [
+            [
+              "textDocument/definition",
+              "textDocument/documentSymbol"
+            ]
+          ]
+        }
+      }
+    },
+    "configurationDefaults": {
+      "[nix]": {
+        "editor.insertSpaces": true,
+        "editor.tabSize": 2
+      }
+    },
+    "commands": [
+      {
+        "title": "Restart Language Server",
+        "category": "Nix IDE",
+        "command": "nix-ide.restartLanguageServer"
+      }
+    ]
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.6.1",
+    "@commitlint/config-conventional": "^19.6.0",
+    "@types/bun": "latest",
+    "@types/command-exists": "^1.2.3",
+    "@types/node": "^22.10.3",
+    "coc.nvim": "^0.0.83-next.18",
+    "esbuild": "^0.24.2",
+    "globals": "^15.14.0",
+    "husky": "^9.1.7",
+    "js-yaml": "^4.1.0",
+    "ovsx": "^0.10.1",
+    "standard-version": "^9.5.0",
+    "typescript": "^5.7.2"
+  },
+  "scripts": {
+    "patch": "scripts/patch.sh ../src/*.ts",
+    "prebuild": "bun run patch",
+    "build-base": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:coc.nvim --format=cjs --platform=node",
+    "build": "bun run build-base --sourcemap --minify",
+    "watch": "bun run build-base --sourcemap --watch",
+    "postinstall": "husky",
+    "clean": "rm -rd dist",
+    "prerelease": "bun install && bun run lint && bun run clean && bun run build",
+    "release": "standard-version",
+    "postrelease": "git push --follow-tags",
+    "package": "bun run build && bunx vsce package",
+    "publish:ovsx": "bunx ovsx publish *.vsix --pat '$OVS_PAT'",
+    "publish:vsce": "bunx vsce publish",
+    "publish": "bun run package && bun run publish:vsce && bun run publish:ovsx",
+    "lint": "bun x biome check --write src"
+  },
+  "dependencies": {
+    "command-exists": "^1.2.9",
+    "coc-variables": "^0.0.1"
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+}

--- a/coc-nix/scripts/patch.pl
+++ b/coc-nix/scripts/patch.pl
@@ -1,0 +1,2 @@
+#!/usr/bin/env -S perl -p
+s=//#==;

--- a/coc-nix/scripts/patch.sh
+++ b/coc-nix/scripts/patch.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+cd "$(dirname "$(dirname "$(readlink -f "$0")")")"
+
+for file; do
+  scripts/patch.pl "$file" | cpp -DHAVE_COC_NVIM -xassembler-with-cpp -nostdinc -P -C -o"${file#*/}"
+done

--- a/coc-nix/src/.gitignore
+++ b/coc-nix/src/.gitignore
@@ -1,0 +1,2 @@
+/*
+!/.gitignore

--- a/coc-nix/tsconfig.json
+++ b/coc-nix/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../tsconfig",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "allowSyntheticDefaultImports": true,
+        "noImplicitAny": false
+    }
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,10 +2,16 @@ import {
   type ConfigurationChangeEvent,
   type WorkspaceConfiguration,
   workspace,
+//# #if HAVE_VSCODE
 } from "vscode";
 import type { LSPObject } from "vscode-languageclient";
-
 import type { MessageItem, Uri } from "vscode";
+//# #elif HAVE_COC_NVIM
+//# } from "coc.nvim";
+//# import type { LSPObject } from "coc.nvim";
+//# import type { MessageItem, Uri } from "coc.nvim";
+//# #endif
+
 import { transformConfigValueByVscodeVariables } from "./utils";
 
 export interface UriMessageItem extends MessageItem {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,10 @@
+//# #if HAVE_VSCODE
 import * as vscode from "vscode";
 import type { ExtensionContext } from "vscode";
+//# #elif HAVE_COC_NVIM
+//# import * as vscode from "coc.nvim";
+//# import type { ExtensionContext } from "coc.nvim";
+//# #endif
 import * as client from "./client";
 import { config } from "./configuration";
 import { formattingProviders } from "./formatter";
@@ -27,8 +32,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
   } else {
     await startLinting(context);
     const subs = [
+      //# #if HAVE_VSCODE
       vscode.languages.registerDocumentFormattingEditProvider,
       vscode.languages.registerDocumentRangeFormattingEditProvider,
+      //# #elif HAVE_COC_NVIM
+      //# vscode.languages.registerDocumentFormatProvider,
+      //# vscode.languages.registerDocumentRangeFormatProvider,
+      //# #endif
     ].map((func) => func("nix", formattingProviders));
     context.subscriptions.concat(subs);
   }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,11 +1,16 @@
-import * as vscode from "vscode";
 import {
   type DocumentFormattingEditProvider,
   type DocumentRangeFormattingEditProvider,
   Range,
   type TextDocument,
   TextEdit,
+//# #if HAVE_VSCODE
 } from "vscode";
+import * as vscode from "vscode";
+//# #elif HAVE_COC_NVIM
+//# Uri
+//# } from "coc.nvim";
+//# #endif
 import { config } from "./configuration";
 import { type IProcessResult, runInWorkspace } from "./process-runner";
 
@@ -24,14 +29,29 @@ const getFormatRangeEdits = async (
   document: TextDocument,
   range?: Range,
 ): Promise<ReadonlyArray<TextEdit>> => {
+  //# #if HAVE_VSCODE
   const actualRange = document.validateRange(
     range || new Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE),
   );
+  //# #elif HAVE_COC_NVIM
+  //# const actualRange = range || Range.create(0, 0, Number.MAX_VALUE, Number.MAX_VALUE);
+  //# #endif
   let result: IProcessResult;
   try {
+    //# #if HAVE_VSCODE
     FORMATTER.forEach((elm, i) => {
       FORMATTER[i] = elm.replace("{file}", document.fileName);
     });
+    //# #elif HAVE_COC_NVIM
+    //# FORMATTER.forEach(
+    //#   (elm, i) => {
+    //#     FORMATTER[i] = elm.replace(
+    //#       "{file}",
+    //#       Uri.parse(document.uri).fsPath /* document.fileName */,
+    //#     )
+    //#   },
+    //# );
+    //# #endif
     result = await runInWorkspace(
       vscode.workspace.getWorkspaceFolder(document.uri),
       FORMATTER,

--- a/src/process-runner.ts
+++ b/src/process-runner.ts
@@ -1,5 +1,10 @@
 import { execFile } from "node:child_process";
+//# #if HAVE_VSCODE
 import type { WorkspaceFolder } from "vscode";
+//# #elif HAVE_COC_NVIM
+//# import type { WorkspaceFolder } from "coc.nvim";
+//# import { Uri } from "coc.nvim";
+//# #endif
 
 /**
  * A system error, i.e. an error that results from a syscall.
@@ -72,7 +77,11 @@ export const runInWorkspace = (
   stdin?: string,
 ): Promise<IProcessResult> =>
   new Promise((resolve, reject) => {
+    //# #if HAVE_VSCODE
     const cwd = folder ? folder.uri.fsPath : process.cwd();
+    //# #elif HAVE_COC_NVIM
+    //# const cwd = folder ? Uri.parse(folder.uri).fsPath : process.cwd();
+    //# #endif
     const child = execFile(
       command[0],
       command.slice(1),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,10 @@
+//# #if HAVE_VSCODE
 import type { LSPObject } from "vscode-languageclient";
 import variables from "vscode-variables";
+//# #elif HAVE_COC_NVIM
+//# import type { LSPObject } from "coc.nvim";
+//# import variables from "coc-variables";
+//# #endif
 
 /**
  * transform config value by vscode variables


### PR DESCRIPTION

![a](https://github.com/user-attachments/assets/f25f4651-b94c-4c2e-b9b7-ec183773db60)

https://www.npmjs.com/package/coc-nix

Refer:
https://github.com/valentjn/vscode-ltex/blob/3d0cb8cd9b4d0dc8ef6c08a4f376767820678cf6/src/extension.ts#L8-L14

Difference is vscode-ltex/coc-ltex uses a customized python script
https://github.com/valentjn/vscode-ltex/blob/3d0cb8cd9b4d0dc8ef6c08a4f376767820678cf6/tools/patchForTarget.py
to patch code
we use c language macro preprocessor cpp
