### PR TITLE
fix: default to nixfmt formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ You can also open the Command Palette (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</
 1. Install the extension
 2. Open a Nix file
 3. Syntax highlighting should work out of the box.
-4. Formatting the code should work if `nixpkgs-fmt` is installed and available on the PATH.
+4. Formatting the code should work if [`nixfmt`](https://github.com/NixOS/nixfmt) (or the archived [`nixpkgs-fmt`](https://github.com/nix-community/nixpkgs-fmt)) is installed and available on the `$PATH`.
 5. Full language support is available if you have a language server installed and enabled. See [LSP Plugin Support](#lsp-plugin-support) for more information.
 
 ## Features 🎯
 
 - [Syntax Highlighting](./images/docs/nix-syntax-highlight.png) support. Also Nix code blocks inside `markdown` files also [highlighted](./images/docs/md-embed-nix.png).
-- The basic language integration is supported out of the box using `nixpkgs-fmt` and `nix instantiate`. Syntax Errors are [linted](./images/docs/linting.png) using `nix-instantiate` while Auto-Formatting is handled by `nixpkgs-fmt` by default. Custom formatter can be set by [setting `nix.formatterPath`](#custom-formatter).
+- The basic language integration is supported out of the box using `nixfmt` and `nix-instantiate`. Syntax Errors are [linted](./images/docs/linting.png) using `nix-instantiate` while Auto-Formatting is handled by `nixfmt` by default. Custom formatter can be set by [setting `nix.formatterPath`](#custom-formatter).
 - The full language support is enabled by [configuring an LSP server](#lsp-plugin-support).
 - Snippets are provided for conditional expressions, `let` expressions, `with` expressions, and `rec`ursive sets.
-- Path completion support using https://github.com/ChristianKohler/PathIntellisense extension
+- Path completion support using [PathIntellisense](https://github.com/ChristianKohler/PathIntellisense) extension
 
 ## Settings ⚙️
 
@@ -32,7 +32,7 @@ It can be changed by setting `nix.formatterPath` to any command which can accept
 
 ```json5
 { 
-    "nix.formatterPath": "nixpkgs-fmt" // or "nixfmt" or ["treefmt", "--stdin", "{file}"]
+    "nix.formatterPath": "nixfmt" // or "nixpkgs-fmt" or ["treefmt", "--stdin", "{file}"]
     // or using flakes with `formatter = pkgs.alejandra;`
     // "nix.formatterPath": ["nix", "fmt", "--", "--"]
 }
@@ -50,10 +50,12 @@ Full language support can be enabled by using a language server. Generally, any 
   "nix.serverSettings": { ... }
 }
 ```
-Some examples of advanced settings are provided below for [nil](https://github.com/oxalica/nil) and [nixd](https://github.com/nix-community/nixd).
+Some examples of advanced settings are provided below for [`nil`](https://github.com/oxalica/nil) and [`nixd`](https://github.com/nix-community/nixd).
 
-* [Nil Advanced Settings](./docs/snippets/advanced-nil-settings.jsonc)
-* [Nixd Advanced Settings](./docs/snippets/advanced-nixd-settings.jsonc)
+* [`nil` Advanced Settings](./docs/snippets/advanced-nil-settings.jsonc)
+  * See the [settings documentation](https://github.com/oxalica/nil/blob/main/docs/configuration.md)
+* [`nixd` Advanced Settings](./docs/snippets/advanced-nixd-settings.jsonc)
+  * See the [settings documentation](https://github.com/nix-community/nixd/blob/main/nixd/docs/configuration.md)
 
 ## Contributing 💪
 

--- a/docs/snippets/advanced-nil-settings.jsonc
+++ b/docs/snippets/advanced-nil-settings.jsonc
@@ -1,4 +1,6 @@
 {
+  // nil configuration documentation :
+  // https://github.com/oxalica/nil/blob/main/docs/configuration.md
   "nix.enableLanguageServer": true,
   "nix.serverPath": "nil",
   "nix.serverSettings": {
@@ -7,7 +9,7 @@
         "ignored": ["unused_binding", "unused_with"],
       },
       "formatting": {
-        "command": ["nixpkgs-fmt"],
+        "command": ["nixfmt"],
       },
     },
   },

--- a/docs/snippets/advanced-nixd-settings.jsonc
+++ b/docs/snippets/advanced-nixd-settings.jsonc
@@ -1,10 +1,12 @@
 {
+  // nixd configuration documentation :
+  // https://github.com/nix-community/nixd/blob/main/nixd/docs/configuration.md#configuration-overview 
   "nix.enableLanguageServer": true,
   "nix.serverPath": "nixd",
   "nix.serverSettings": {
     "nixd": {
       "formatting": {
-        "command": ["nixpkgs-fmt"],
+        "command": ["nixfmt"],
       },
       "options": {
         // By default, this entry will be read from `import <nixpkgs> { }`.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
             "string",
             "array"
           ],
-          "default": "nixpkgs-fmt",
+          "default": "nixfmt",
           "description": "Location of the nix formatter command."
         },
         "nix.serverPath": {
@@ -86,7 +86,7 @@
         "nix.enableLanguageServer": {
           "type": "boolean",
           "default": false,
-          "description": "Use LSP instead of nix-instantiate and nixpkgs-fmt."
+          "description": "Use LSP instead of nix-instantiate and nixfmt."
         },
         "nix.serverSettings": {
           "type": "object",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -29,7 +29,7 @@ export class Config {
   }
 
   get formatterPath(): string | Array<string> {
-    return this.get<string>("formatterPath", "nixpkgs-fmt");
+    return this.get<string>("formatterPath", "nixfmt");
   }
 
   get serverPath(): string {


### PR DESCRIPTION
# Description 📣 

As described in https://github.com/nix-community/vscode-nix-ide/issues/433#issuecomment-2596040064, since `nixpkgs-fmt`'s project is slowly sun-setting and `nixfmt` is taking over, we're changing the default for this extension.

# Tests 🧪

Tests have been made on my end (on NixOS) : 
1. Installing [`nixfmt-rfc-style`](https://search.nixos.org/packages?channel=24.11&from=0&size=30&sort=relevance&type=packages&query=nixfmt-rfc-style)
2. Changing `nix.formatterPath` to `nixfmt`
3. Making sure it'll use it by disabling the `nix.enableLanguageServer = false`
4. Opened a .nix file made some fuzzy changes, saved and saw the content being formatted by `nixfmt`
5. I haven't seen any error message