### PR TITLE
fix: issue warning on missing `nil`/`nixd`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -117,7 +117,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
             if (!item?.section) {
               continue;
             }
-            res.push(settings[item.section as keyof typeof settings] ?? null);
+            const sectionSettings = settings[item.section as keyof typeof settings]
+            if (!sectionSettings) {
+              client.warn(`failed to find "${item.section}" in "nix.serverSettings"`)
+            }
+            res.push(sectionSettings ?? null);
           }
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return res;


### PR DESCRIPTION
Issues a warning if the extension fails to find the configured LSP.

Related to #464, as it would've provided a nice clue as to where the issue was.