### PR TITLE
fix: shell.nix with bun instead of yarn (fixes #473)

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,6 @@ pkgs.mkShell {
     bun
   ];
   shellHook = ''
-    yarn install
+    bun install
   '';
 }


### PR DESCRIPTION
Fixes #473.