### PR TITLE
feat: auto-indent on pressed enter

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -106,5 +106,55 @@
             "end": "^\\s*#\\s*#?endregion\\b"
         }
     },
+    "onEnterRules": [
+        {
+            "beforeText": "^.*\\blet\\s*$",
+            "afterText": "\\s*in\\b.*$",
+            "action": {
+                "indent": "indentOutdent"
+            }
+        },
+        {
+            "beforeText": "^.*\\bif\\s*$",
+            "afterText": "\\s*then\\b.*$",
+            "action": {
+                "indent": "indentOutdent"
+            }
+        },
+        {
+            "beforeText": "^.*\\bthen\\s*$",
+            "afterText": "\\s*else\\b.*$",
+            "action": {
+                "indent": "indentOutdent"
+            }
+        },
+        {
+            "beforeText": "^.*''\\s*$",
+            "afterText": "\\s*''.*$",
+            "action": {
+                "indent": "indentOutdent"
+            }
+        },
+        {
+            "beforeText": "^.*/\\*\\*\\s*$",
+            "afterText": "\\s*\\*/.*$",
+            "action": {
+                "indent": "indentOutdent"
+            }
+        },
+        {
+            "beforeText": "^.*(?:=|/\\*\\*)\\s*$",
+            "action": {
+                "indent": "indent"
+            }
+        },
+        {
+            // NOTE: `in` is not included on purpose, because nixfmt also doesn't indent after it.
+            "beforeText": "^.*\\b(?:let|with|if|then|else|rec|or|and|assert|inherit)\\s*$",
+            "action": {
+                "indent": "indent"
+            }
+        },
+    ],
     "wordPattern": "(-?\\d*\\.\\d\\w*)|((~|[^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\<\\>\\/\\?\\s]+)/[^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\<\\>\\?\\s]+)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)"
 }


### PR DESCRIPTION
### Changes in this PR:
1. Insert indent when pressing Enter after some symbols, e.g. after `=`.
2. Insert indent and outdent when pressing Enter in between some symbols. e.g. between `let` and `in`. Note, that vscode by default already does that for `{}`, `[]`, `()`. 

### Examples of the new behavior (cursor is marked as `|`):

#### Example 1
```nix
{
  a = |
}

# after pressing Enter:

{
  a = 
    |
}
```

#### Example 2 
```nix
let |in {}

# after pressing Enter:

let
  |
in {}

```