### PR TITLE
fix: add auto-indent for multi-line strings

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -143,7 +143,7 @@
             }
         },
         {
-            "beforeText": "^.*(?:=|/\\*\\*)\\s*$",
+            "beforeText": "^.*(?:=|/\\*\\*|'')\\s*$",
             "action": {
                 "indent": "indent"
             }


### PR DESCRIPTION
Somehow missed this in the previous PR.

Before vs After this PR. (`|` is cursor)

Before:
```nix
a = ''|
  lorem ipsum
''

# after pressing Enter:

a = ''
|
  lorem ipsum
''
```

This PR:
```nix
a = ''|
  lorem ipsum
''

# after pressing Enter:

a = ''
  |
  lorem ipsum
''
```
