### PR TITLE
docs (README.md): update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Adds [Nix](https://nixos.org/) language support for [Visual Studio Code](https:/
 
 1. [Install](./install.md) the extension, and open a Nix file.
 1. [Syntax highlighting](./images/docs/nix-syntax-highlight.png) should work out of the box. Nix code blocks inside `markdown` files are also [supported](./images/docs/md-embed-nix.png).
-1. Auto-formatting should work if [`nixfmt`](https://github.com/NixOS/nixfmt) or [`nixpkgs-fmt`](https://github.com/nix-community/nixpkgs-fmt) is available in `$PATH`. A custom formatter can be set by [configuring `nix.formatterPath`](#custom-formatter).
+1. Auto-formatting should work if [`nixfmt`](https://github.com/NixOS/nixfmt) is available in `$PATH`. A custom formatter can be set by [configuring `nix.formatterPath`](#custom-formatter).
 1. Syntax errors are [linted](./images/docs/linting.png) using `nix-instantiate`.
 1. Full language support can be enabled by configuring a language server. See [LSP Plugin Support](#lsp-plugin-support) for more information.
 1. Snippets are provided for conditional expressions, `let`/`with` expressions, and `rec`ursive sets.
@@ -64,7 +64,7 @@ It can be changed by setting `nix.formatterPath` to any command which can accept
 
 ```json5
 {
-    "nix.formatterPath": "nixfmt" // or "nixpkgs-fmt" or "alejandra" or "nix3-fmt"
+    "nix.formatterPath": "nixfmt" // or "alejandra"
     // or pass full list of args like below
     // "nix.formatterPath": ["treefmt", "--stdin", "{file}"]
 }


### PR DESCRIPTION
Removed reference to nix3-fmt in nix.formatterPath example, since it's not actually a package but rather a manual page E.g., "nix3-fmt(1)"  used at https://man.archlinux.org/man/extra/nix/nix3-fmt.1.en.

Removed link and reference to repository "nixpkgs-fmt" that was archived by the owner on Jul 24, 2024 and is now read-only.  It has been replaced by the already mentioned nixfmt repository at https://github.com/NixOS/nixfmt.