### PR TITLE
feat: add semantic token default scopes for nil

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,101 @@
         "category": "Nix IDE",
         "command": "nix-ide.restartLanguageServer"
       }
+    ],
+    "semanticTokenTypes": [
+      {
+        "id": "boolean",
+        "description": "Style for boolean literals",
+        "superType": "keywords"
+      },
+      {
+        "id": "constant",
+        "description": "Style for `builtins` constants"
+      },
+      {
+        "id": "path",
+        "description": "Style for paths"
+      },
+      {
+        "id": "punctuations",
+        "description": "Style for punctuations"
+      }
+    ],
+    "semanticTokenModifiers": [
+      {
+        "id": "builtin",
+        "description": "Style for `builtins` variables and functions"
+      },
+      {
+        "id": "conditional",
+        "description": "Style for conditional operators and keywords"
+      },
+      {
+        "id": "delimiter",
+        "description": "Style for delimiter punctuations"
+      },
+      {
+        "id": "escape",
+        "description": "Style for escape sequences in strings"
+      },
+      {
+        "id": "parenthesis",
+        "description": "Style for parenthesis"
+      },
+      {
+        "id": "unresolved",
+        "description": "Style for unresolved variables"
+      },
+      {
+        "id": "withAttribute",
+        "description": "Style for attributes from `with`"
+      }
+    ],
+    "semanticTokenScopes": [
+      {
+        "language": "nix",
+        "scopes": {
+          "boolean": [
+            "constant.language.boolean.nix"
+          ],
+          "constant.builtin": [
+            "support.const.nix"
+          ],
+          "function.builtin": [
+            "support.function.nix"
+          ],
+          "struct.builtin": [
+            "support.const.nix"
+          ],
+          "path": [
+            "constant.other.path.nix"
+          ],
+          "string": [
+            "string.quoted.double.nix"
+          ],
+          "string.escape": [
+            "constant.character.escape.nix"
+          ],
+          "variable": [
+            "variable.other.nix"
+          ],
+          "variable.unresolved": [
+            "invalid.nix"
+          ],
+          "parameter": [
+            "variable.parameter.name.nix"
+          ],
+          "property": [
+            "entity.other.attribute-name.single.nix"
+          ],
+          "*.withAttribute": [
+            "markup.underline"
+          ],
+          "operator": [
+            "entity.name.operator.nix"
+          ]
+        }
+      }
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
We (nil) support semantic highlighting for a long time, but it turns out the out-of-box highlighting on vscode looks suboptimal. Non-standard token types and modifiers are not colored differently without explicit scope definitions.
This patch add documentations for non-standard semantic token types and modifiers, and assign scope names for them. So themes can pick up default colors for them correctly.

My intent is to make it visually distinct for variables, attributes and dynamic attributes from "with" expression. But it still highly depends on themes about if these scopes are using the same color. Currently attributes from with-exprs are underlined (if the theme supports it).
Anyway, users can fine-tune or override these scopes and/or colors in their settings.

Here are some screenshots after this patch, with only specific theme selected, no manual color configurations.

<details>
<summary>"One Dark Pro" theme (Distinguishes between variables and attributes but not with parameters.):</summary>

![image](https://github.com/user-attachments/assets/82a0df76-accc-4376-a1c8-ccfcce5dc6f9)

</details>

<details>
<summary>"Dracula" theme (Distinguishes between variables, attributes and parameters.):</summary>

![image](https://github.com/user-attachments/assets/3620d6e7-14ed-469d-86c5-6cd0ee33258b)

</details>

<details>
<summary>"Dark Modern" theme (Does not, by-design, distinguish between attributes and variables)</summary>

![image](https://github.com/user-attachments/assets/63097a31-6092-4cac-92f3-5322d31de711)

</details>

<details>
<summary>"Light Modern" theme (Upstream said attributes names are bloody red by design. They don't want to change it):</summary>

Upstream issue: https://github.com/microsoft/vscode/issues/199564

![image](https://github.com/user-attachments/assets/814e49d8-4983-47b6-8c06-bb67af80202f)

</details>

<details>
<summary>Screenshots before this patch, with nil's semantic tokens enabled</summary>

"One Dark Pro" theme:
![image](https://github.com/user-attachments/assets/414136d2-668a-45ea-95df-5b61d0c8beb0)

"Dracula" theme:
![image](https://github.com/user-attachments/assets/bbf7b4b4-5b55-4b28-9e1f-d35150ac193e)

"Dark Modern" theme:
![image](https://github.com/user-attachments/assets/e097d840-1bfa-4697-bd96-c4d0a7218fa9)

"Light Modern" theme (Note: Attributes are rendered as blue because semantic token type `property` is mapped to `variable.property` and rendered as variables. This is incorrect because attributes are not variables.):
![image](https://github.com/user-attachments/assets/0531b935-fbd9-4118-ab60-3234c37ae71d)

"Light Modern" theme, with LSP disabled.
![image](https://github.com/user-attachments/assets/51c41bb7-eb4b-4bd2-beca-85ad9ec7c4a8)


</details>