### PR TITLE
feat: add backticks to surroundingPairs

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -99,6 +99,11 @@
             "''",
             "''"
         ],
+        // Backticks don't have any special meaning in nix language, it's just for Markdown in comments.
+        [
+            "`",
+            "`"
+        ],
     ],
     "folding": {
         "markers": {


### PR DESCRIPTION
What this does, is when a text is selected and pressing <code>\`</code> it will surround with <code>\`\`</code> instead of replacing the selection with <code>`</code>.