### PR TITLE
feat: set explorer.fileNesting for flake.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,9 @@
       "[nix]": {
         "editor.insertSpaces": true,
         "editor.tabSize": 2
+      },
+      "explorer.fileNesting.patterns": {
+        "flake.nix": "flake.lock"
       }
     },
     "commands": [


### PR DESCRIPTION
Adds default configuration for file nesting for flake.lock.
This is similar to what other extensions for languages with lockfiles do, e.g. https://github.com/rust-lang/rust-analyzer/issues/13580.

It can be enabled/disabled globally via `explorer.fileNesting.enabled`.

Before:
<img width="250" height="219" alt="image" src="https://github.com/user-attachments/assets/1ef5fb75-e646-4901-b188-99d0d9393704" />

After:
<img width="244" height="225" alt="image" src="https://github.com/user-attachments/assets/a7078831-6e1e-45bd-a3c7-67b21d9405f7" />
