### PR TITLE
fix(launch.json): launch task hanging on npmWatch

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,22 @@
 			"label": "npmWatch",
 			"isBackground": true,
 			"detail": "bun run watch",
-			"problemMatcher": "$esbuild-watch"
+			// This is needed so vscode doesn't block when this is ran as preLaunchTask.
+			"problemMatcher": {
+				"pattern": [
+					{
+						"regexp": ".",
+						"file": 1,
+						"line": 2,
+						"message": 5,
+					}
+				],
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": ".",
+					"endsPattern": ".",
+				}
+			}
 		}
 	]
 }


### PR DESCRIPTION
When I press F5 to run `extensionHost` task, it hangs on `npmWatch`. This PR fixes that. 

The solution is based on https://stackoverflow.com/a/54017304.