### PR TITLE
update(manifest): `serverPath` default to `nixd`

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         },
         "nix.serverPath": {
           "type": "string",
-          "default": "nil",
+          "default": "nixd",
           "description": "Location of the nix language server command."
         },
         "nix.enableLanguageServer": {


### PR DESCRIPTION
Since https://github.com/nix-community/nixd has become the https://github.com/nix-community supported nix lsp, and the seemingly overwhelming preference for nixd, it might be time to prefer it compared to https://github.com/oxalica/nil