### PR TITLE
update(manifest): `enableLanguageServer` default to true

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         },
         "nix.enableLanguageServer": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Use LSP instead of nix-instantiate and the formatter configured via `nix.formatterPath`."
         },
         "nix.serverSettings": {


### PR DESCRIPTION
Given that the usage and stabilization of LSPs (notably https://github.com/nix-community/nixd) in the nix ecosystem has become prevalent, it might be time to consider having it be used as default compared to using `nix-instantiate` and https://github.com/NixOS/nixfmt

## Related

- #505