### PR TITLE
fix: array concatenation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       vscode.languages.registerDocumentFormattingEditProvider,
       vscode.languages.registerDocumentRangeFormattingEditProvider,
     ].map((func) => func("nix", formattingProviders));
-    context.subscriptions.concat(subs);
+    context.subscriptions.push(...subs);
   }
 
   context.subscriptions.push(


### PR DESCRIPTION
[`Array.prototype.concat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat) does not modify the array. It returns a modified copy. You need [`Array.prototype.push`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push) to do that.

```js
let arr = []

arr.concat([1,2,3]) // returns [1, 2, 3]
console.log(arr) // prints []

arr.push(...[1,2,3]) // returns 3
console.log(arr) // prints [1, 2, 3]
```