### PR TITLE
fix: extension restart error

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,7 +59,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "nix-ide.restartLanguageServer",
-      restartLSP,
+      () => restartLSP(context),
     ),
   );
 


### PR DESCRIPTION

<img width="573" height="126" alt="image" src="https://github.com/user-attachments/assets/adc2a710-53b3-4fb6-bfce-cff1c441d7d2" />


Restarting the LSP throws an error:

```
I[08:24:18.682] 400618: <-- initialize(0)
I[08:24:18.682] 400618: --> reply:initialize(0)
[Error - 8:24:18 AM] Failed to restart Nix language server
TypeError: Cannot read properties of undefined (reading 'subscriptions')
	at R6 (/home/nixos/.vscodium-server/extensions/jnoortheen.nix-ide-0.5.10-universal/dist/extension.js:44:46178)
	at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
	at async jK (/home/nixos/.vscodium-server/extensions/jnoortheen.nix-ide-0.5.10-universal/dist/extension.js:44:46397)
	at async UK (/home/nixos/.vscodium-server/extensions/jnoortheen.nix-ide-0.5.10-universal/dist/extension.js:44:48892)
	at async bS._executeContributedCommand (file:///home/nixos/.vscodium-server/bin/221e0a382c0be3a673a4e4cab0601344a0b3de3a/out/vs/workbench/api/node/extensionHostProcess.js:116:49482)
```

`restartLSP` expects an `ExtensionContext`, but command handlers receive command arguments rather than the extension activation context. Invoking the restart command from the command palette therefore called `restartLSP(undefined)`.

The language client started successfully, but `client.activate` subsequently failed at `context.subscriptions.push(client)` with:

    TypeError: Cannot read properties of undefined (reading 'subscriptions')

Capture the activation context in the registered callback, restoring the behavior used before the restart handler was extracted.

Tested with `bun run test` and by restarting nixd through the command.