### PR TITLE
fix: formatter {file} stripping

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,5 +19,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: bun run pretest
+      - run: bun run test:unit
       - run: bun run package
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/package.json
+++ b/package.json
@@ -281,6 +281,7 @@
     "publish:ovsx": "ovsx publish *.vsix --pat '$OVS_PAT'",
     "publish:vsce": "vsce publish",
     "publish": "bun run package && bun run publish:vsce && bun run publish:ovsx",
+    "test:unit": "bun test '.test.ts' --path-ignore-patterns 'src/extension.test.ts'",
     "test": "bun run build --sourcemap && vscode-tmgrammar-snap 'syntax-tests/*.nix'",
     "full-test": "vscode-test",
     "pretest": "bun x biome check --write src"

--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { CancellationToken, TextDocument } from "vscode";
+
+const formatterInvocations: string[][] = [];
+
+mock.module("vscode", () => ({
+  Range: class Range {},
+  TextEdit: { replace: () => ({}) },
+  window: { showErrorMessage: async () => undefined },
+  workspace: { getWorkspaceFolder: () => undefined },
+}));
+
+mock.module("./configuration", () => ({
+  config: { formatterPath: ["treefmt", "--stdin", "{file}"] },
+}));
+
+mock.module("./process-runner", () => ({
+  runInWorkspace: async (_workspace: unknown, formatter: string[]) => {
+    formatterInvocations.push([...formatter]);
+    return { exitCode: 1, stderr: "", stdout: "" };
+  },
+}));
+
+const { formattingProviders } = await import("./formatter");
+
+const document = (fileName: string): TextDocument =>
+  ({
+    fileName,
+    getText: () => "",
+    uri: {},
+    validateRange: (range: unknown) => range,
+  }) as unknown as TextDocument;
+
+const formattingOptions = { insertSpaces: true, tabSize: 2 };
+const cancellationToken = {
+  isCancellationRequested: false,
+} as CancellationToken;
+
+describe("fallback formatter command", () => {
+  test("resolves the file placeholder for every document", async () => {
+    await formattingProviders.provideDocumentFormattingEdits(
+      document("/workspace/first.nix"),
+      formattingOptions,
+      cancellationToken,
+    );
+    await formattingProviders.provideDocumentFormattingEdits(
+      document("/workspace/second.nix"),
+      formattingOptions,
+      cancellationToken,
+    );
+
+    expect(formatterInvocations).toEqual([
+      ["treefmt", "--stdin", "/workspace/first.nix"],
+      ["treefmt", "--stdin", "/workspace/second.nix"],
+    ]);
+  });
+});

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -9,8 +9,6 @@ import {
 import { config } from "./configuration";
 import { type IProcessResult, runInWorkspace } from "./process-runner";
 
-const FORMATTER: Array<string> = config.formatterPath;
-
 /**
  * Get text edits to format a range in a document.
  *
@@ -25,20 +23,23 @@ const getFormatRangeEdits = async (
   const actualRange = document.validateRange(
     range || new Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE),
   );
+  // The configured command is a template shared by every document. Resolving it
+  // into a new array keeps `{file}` available for later requests and lets each
+  // invocation observe the current configuration.
+  const formatter = config.formatterPath.map((argument) =>
+    argument.replace("{file}", document.fileName),
+  );
   let result: IProcessResult;
   try {
-    FORMATTER.forEach((elm, i) => {
-      FORMATTER[i] = elm.replace("{file}", document.fileName);
-    });
     result = await runInWorkspace(
       vscode.workspace.getWorkspaceFolder(document.uri),
-      FORMATTER,
+      formatter,
       document.getText(actualRange),
     );
   } catch (error) {
     if (error instanceof Error) {
       await vscode.window.showErrorMessage(
-        `Failed to run ${FORMATTER.join(" ")}: ${error.message}`,
+        `Failed to run ${formatter.join(" ")}: ${error.message}`,
       );
     }
     // Re-throw the error to make the promise fail


### PR DESCRIPTION
the first formatting execution actually replaced the {file} placeholder, meaning it would only re-format the first file, independent of later format target files.