### PR TITLE
fix: remove angle brackets from language configuration brackets list

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -26,10 +26,6 @@
             "(",
             ")"
         ],
-        [
-            "<",
-            ">"
-        ]
     ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [


### PR DESCRIPTION
This PR fixes syntax highlighting for operators that use angle brackets.

|Before|After|
|-|-|
|<img width="433" height="347" alt="nix_before" src="https://github.com/user-attachments/assets/e792d366-9925-4ce0-bf75-41c12dc45ac8" />|<img width="433" height="347" alt="nix_after" src="https://github.com/user-attachments/assets/d3360c73-9570-4ae9-8302-8f30ed1f9a25" />|


This unfortunately removes the ability to use "Select to Bracket" and the like on lookup paths (`<nixpkgs>`).
However, it does seem to be [the solution](https://stackoverflow.com/a/75626056) recommended by a prominent VSCode maintainer:
> Long term, languages contributed by extensions should only configure `brackets` that always match (i.e. `<`...`>` should not be marked as a bracket pair or both brackets should have the same language id).

This would close #508.